### PR TITLE
chore: 清理 .gitignore 中残留的 data/ 规则

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,8 +7,6 @@ __pycache__/
 *$py.class
 *.so
 
-# 数据目录（用户本地生成）
-data/products/*.json
 
 # 环境变量配置（可能包含敏感信息）
 .env
@@ -25,5 +23,3 @@ data/products/*.json
 .DS_Store
 Thumbs.db
 
-# 数据文件已迁移到 workspace/1688-skill-data/，忽略 skill 目录内的旧数据
-data/


### PR DESCRIPTION
## 背景

PR #2 合并后，`data/` 目录已从 skill 目录完全删除（数据迁移到 `workspace/1688-skill-data/`）。
但 `.gitignore` 中仍残留了对应的忽略规则，已无实际意义。

## 变更

- 删除 `.gitignore` 中的 `data/products/*.json` 规则
- 删除 `.gitignore` 中的 `data/` 规则
- 删除相关注释

## 说明

本 PR 基于最新 main 分支（包含 PR #2 全部内容），无冲突。