### PR TITLE
docs: add new-merchant store SOP and wire FAQ routing

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -106,5 +106,6 @@ Agent 根据用户意图**直接执行对应命令**，无需每次先执行 `ch
 | 运费模板、定价、加价倍率 | `references/faq/listing-template.md` |
 | 发货超时、中转费、偏远地区 | `references/faq/fulfillment.md` |
 | 退货、仅退款、运费险、售后 | `references/faq/after-sales.md` |
+| 新人开店、开店流程、SOP、从零起步、第一步做什么 | `references/faq/new-merchant-store-sop.md` |
 | 新店破零、服务分、推广 | `references/faq/new-store.md` |
 | 素材审核、白底图、标题优化 | `references/faq/content-compliance.md` |

--- a/references/faq/new-merchant-store-sop.md
+++ b/references/faq/new-merchant-store-sop.md
@@ -1,0 +1,61 @@
+# 新人开店 SOP（标准流程）
+
+面向首次使用本工具、从零到可铺货的状态。每步完成后进入下一步；细节问答见文末链出的 FAQ。
+
+---
+
+## 阶段一：账号与 AK
+
+1. 安装并打开 [**1688 AI 版 APP**](https://air.1688.com/kapp/1688-ai-app/pages/home?from=1688-shopkeeper)，按首页指引获取 **AK（Access Key）**。
+2. 在本机配置 AK：执行 `cli.py configure <你的AK>`，或设置环境变量 `ALI_1688_AK`（与 APP 中一致）。
+3. 可选：执行 `cli.py check`，确认 AK 与运行环境正常。
+
+若报错「AK 未配置」「401」等，按 SKILL.md 中的 **AK 引导话术** 处理；技术项见 `references/faq/base.md`。
+
+---
+
+## 阶段二：下游开店与店铺绑定
+
+1. 在目标电商平台（抖店、拼多多、小红书、淘宝等）完成开店/入驻，按各平台要求提交资质。
+2. 回到 **1688 AI 版 APP**，完成与下游店铺的绑定（首页「一键开店」等入口，以 APP 当前界面为准）。
+3. 执行 `cli.py shops`，确认列表中能看到目标店铺，并记下对应 **`shop_code`**（铺货必填）。
+
+若返回 0 个店铺，按 SKILL.md **开店引导话术** 引导用户完成绑定后再查。
+
+**选平台、各平台优劣**：见 `references/faq/platform-selection.md`。
+
+---
+
+## 阶段三：首单选品与铺货
+
+1. **搜货**：`cli.py search --query "你的选品描述" --channel <目标渠道>`（如 `douyin`）。保存返回中的 **`data_id`** 与意向商品的 **`product_id`**。
+2. **确认店铺**：再次 `shops`，确认 `shop_code` 与目标店一致。
+3. **铺货（必须先预检）**：对 `publish` **必须先带 `--dry-run`**，预检通过后再正式铺货；仅当商品或店铺存在多个候选时，再请用户明确选择。正式命令示例：`cli.py publish --shop-code <shop_code> --data-id <data_id>`（或按能力文档使用 `--item-ids`）。
+
+铺货安全规则与参数细节见 `references/capabilities/publish.md`；选品思路见 `references/faq/product-selection.md`。
+
+---
+
+## 阶段四：开业后运营（按需）
+
+| 诉求 | 建议命令 / 说明 |
+|------|-----------------|
+| 看即时商机 | `cli.py opportunities` |
+| 看某类目趋势与价格带 | `cli.py trend --query "关键词"` |
+| 经营日报与选品建议 | `cli.py shop_daily` |
+| 商品详情核对 | `cli.py prod_detail --item-ids "id1,id2"` |
+
+破零、服务分、支付与推广等：**不要在本 SOP 展开**，见 `references/faq/new-store.md`。
+
+---
+
+## 与 FAQ 的分工
+
+| 文档 | 用途 |
+|------|------|
+| 本文 | **按顺序做什么**（流程 SOP） |
+| `new-store.md` | 新店破零、评分、投流、活动等 **问答** |
+| `platform-selection.md` | 平台怎么选 |
+| `product-selection.md` | 选品风险与品类 |
+| `listing-template.md` | 运费模板、定价加价 |
+| `base.md` | AK、铺货失败、支持平台等 **技术 FAQ** |


### PR DESCRIPTION
## 元信息

| 项目 | 说明 |
|------|------|
| **类型** | 文档 / Skill 知识库 |
| **源分支** | `feature/new-merchant-store-sop` |
| **目标分支** | `main` |
| **关联需求** | 为新人提供可执行的开店流程说明，与现有 CLI 能力对齐；不扩展对外接口。 |

---

## 摘要

本 PR 在仓库内新增 **「新人开店」标准操作流程（SOP）** 文档，并在 `SKILL.md` 的 FAQ 知识库中注册路由，使 Agent 在用户询问开店流程、从零起步、SOP 等话题时，能够按需加载该文档并给出与 `search` / `shops` / `publish` 等命令一致的操作顺序。

现有 [`references/faq/new-store.md`](references/faq/new-store.md) 继续承担 **新店破零、服务分、推广** 等问答；新文档专注 **分阶段流程**，职责分离，避免单文件过长、主题混杂。

---

## 背景与动机

- 新用户常需要一条从 **配置 AK → 绑定店铺 → 选品铺货** 的清晰路径，而非分散在多篇 FAQ 中自行拼接。
- 本 Skill 的能力边界已由 `cli.py` 与各 `references/capabilities/*.md` 定义；SOP 应与之一致，并强调 `publish` 须先 **dry-run** 等与 `SKILL.md` 一致的安全规则。
- 不新增 CLI 子命令、不新增 HTTP/API 调用，仅扩展 **内部知识文档与路由**，符合「最小改动、仅内部逻辑」的约束。

---

## 变更说明

### 新增文件

| 文件 | 说明 |
|------|------|
| [`references/faq/new-merchant-store-sop.md`](references/faq/new-merchant-store-sop.md) | 四阶段 SOP：账号与 AK；下游开店与绑定；首单选品与铺货；开业后运营。文末附与 `new-store.md`、`platform-selection.md` 等 FAQ 的分工表。 |

### 修改文件

| 文件 | 说明 |
|------|------|
| [`SKILL.md`](SKILL.md) | 在「FAQ 知识库（按需加载）」表格中增加一行：用户话题包含「新人开店、开店流程、SOP、从零起步、第一步做什么」，指向 `references/faq/new-merchant-store-sop.md`。 |

### 明确未包含的范围

- 未修改 `cli.py`、`scripts/capabilities/*` 及任何对外接口。
- 未修改 [`README.md`](README.md)（可选后续在「快速上手」中增加一句链到 SOP，非本 PR 必需）。

---

## 审阅要点

1. **流程准确性**：各阶段中的命令名称、`shop_code` / `data_id` 等是否与 [`SKILL.md`](SKILL.md) 及 [`references/common/data-contracts.md`](references/common/data-contracts.md) 一致。
2. **与 FAQ 的衔接**：SOP 是否恰当引用 `new-store.md`、`platform-selection.md` 等，避免重复粘贴长段问答。
3. **FAQ 触发词**：`SKILL.md` 表格中的用户话题是否足以覆盖常见自然语言问法。

---

## 验证方式

本变更为文档与 Skill 路由，无自动化测试覆盖。建议审阅时：

1. 本地打开 `references/faq/new-merchant-store-sop.md`，通读阶段顺序与链出路径。
2. 确认 `SKILL.md` 中 FAQ 表新增行格式与同表其他行一致。

---

## 合并后建议

- 在 GitHub 上合并本 PR 后，可将默认分支与远程保持同步；若需对外宣传，可再发小 PR 在 `README.md` 增加一行指向该 SOP 的说明。

---

## Checklist（提交前自检）

- [x] 未引入新的外部 API 或 CLI 子命令。
- [x] SOP 与现有安全规则（如 `publish` 先 dry-run）一致。
- [x] `SKILL.md` 中 YAML front matter 与既有格式未被破坏。

---

## 相关链接

- 对比分支：`feature/new-merchant-store-sop` → `main`
- 主仓库路径（请按实际 fork 替换）：`https://github.com/<org-or-user>/1688-shopkeeper`
